### PR TITLE
Allow following all links with just the number keys

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -155,15 +155,16 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 			}
 
 			links = append(links, url)
-			num := numLinks + len(links) // Visible link number, one-indexed
+			num := numLinks + len(links) // Link number, one-indexed
 
+			linkSelector := toLinkSelector(num)
 			var indent int
 			if num > 99 {
-				// Indent link text by 3 or more spaces
-				indent = len(strconv.Itoa(num)) + 4 // +4 indent for spaces and brackets
+				// Indent link text by 7 or more spaces
+				indent = len(linkSelector) + 3 // +3 indent for space and brackets
 			} else {
 				// One digit and two digit links have the same spacing - see #60
-				indent = 5 // +4 indent for spaces and brackets, and 1 for link number
+				indent = 6 // +4 indent for spaces and brackets, and 1 for link number
 			}
 
 			// Spacing after link number: 1 or 2 spaces?
@@ -172,8 +173,8 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 				// One space to keep it in line with other links - see #60
 				spacing = " "
 			} else {
-				// One digit numbers use two spaces
-				spacing = "  "
+				// One digit numbers use three spaces
+				spacing = "   "
 			}
 
 			// Underline non-gemini links if enabled
@@ -209,7 +210,7 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 
 					// Add special stuff to first line, like the link number
 					wrappedLink[0] = fmt.Sprintf(`[%s::b][`, config.GetColorString("link_number")) +
-						strconv.Itoa(num) + "[]" + "[-::-]" + spacing +
+						linkSelector + "[]" + "[-::-]" + spacing +
 						`["` + strconv.Itoa(num-1) + `"][` + config.GetColorString("amfora_link") + `]` +
 						wrappedLink[0] + `[-][""]`
 				} else {
@@ -222,7 +223,7 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 						false, // Don't indent the first line, it's the one with link number
 					)
 
-					wrappedLink[0] = `[::b][` + strconv.Itoa(num) + "[][::-]  " +
+					wrappedLink[0] = `[::b][` + linkSelector + "[][::-]  " +
 						`["` + strconv.Itoa(num-1) + `"]` +
 						wrappedLink[0] + `[""]`
 				}
@@ -240,7 +241,7 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 					)
 
 					wrappedLink[0] = fmt.Sprintf(`[%s::b][`, config.GetColorString("link_number")) +
-						strconv.Itoa(num) + "[][-::-]" + spacing +
+						linkSelector + "[][-::-]" + spacing +
 						`["` + strconv.Itoa(num-1) + `"]` + linkTag +
 						wrappedLink[0] + `[-::-][""]`
 				} else {
@@ -253,7 +254,7 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 						false, // Don't indent the first line, it's the one with link number
 					)
 
-					wrappedLink[0] = `[::b][` + strconv.Itoa(num) + "[][::-]" + spacing +
+					wrappedLink[0] = `[::b][` + linkSelector + "[][::-]" + spacing +
 						`["` + strconv.Itoa(num-1) + `"]` +
 						wrappedLink[0] + `[::-][""]`
 				}
@@ -315,6 +316,14 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 	}
 
 	return strings.Join(wrappedLines, "\r\n"), links
+}
+
+func toLinkSelector(num int) string {
+	if num <= 9 {
+		return strconv.Itoa(num)
+	}
+	digitCnt := len(strconv.Itoa(num))
+	return strings.Repeat("0", digitCnt-1) + strconv.Itoa(num)
 }
 
 // RenderGemini converts text/gemini into a cview displayable format.

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -27,6 +27,7 @@ type Page struct {
 	Raw          string    // The raw response, as received over the network
 	Content      string    // The processed content, NOT raw. Uses cview color tags. It will also have a left margin.
 	Links        []string  // URLs, for each region in the content.
+	LinkSelector string    // The partial link selection while it is being typed.
 	Row          int       // Vertical scroll position
 	Column       int       // Horizontal scroll position - does not map exactly to a cview.TextView because it includes left margin size changes, see #197
 	TermWidth    int       // The terminal width when the Content was set, to know when reformatting should happen.


### PR DESCRIPTION
I find it mildly annoying to have to type `<spc> + <link-number> + <return>` for links with numbers greater than ten. I thought about how the number of key presses could be reduced and came up with the idea to use the (leading) zero as a special character. Link-numbers larger than nine would get one leading zero, ones larger than 99 would get two, ones larger than 999 would get three and so forth. A picture can probably explain it better:

![demo](https://user-images.githubusercontent.com/42150522/204810062-d752f269-4347-4418-9a3f-5ea0d4610edf.png)

With this change links 1-9 would work as before, for 10 the user would have to type `010` instead of `0`. For 11-99 the user would just need to press three keys instead of four, which is the improvement this pull request is about. I visit a lot of pages that contain more than ten but less than 100 links, so this change would often be useful to me.

PS: This is not meant to be a polished pull request. I just wanted you to be able to try my idea. If you like it, I can continue by adapting the documentation, ...

PPS: I also thought about other ways of reducing key presses for links. One would be to allow some letters in "link selectors", so that ~30-50 links could be followed with a single key press, but I figured it would be too much of a change for the users.