### PR TITLE
Update URLs for official Project Gemini capsule

### DIFF
--- a/client/url_test.go
+++ b/client/url_test.go
@@ -24,9 +24,9 @@ var normalizeURLTests = []struct {
 	{"https://example.com", "https://example.com"},
 	// Fixing URL tests
 	// Some commented out due to #324
-	//{"gemini://gemini.circumlunar.space/%64%6f%63%73/%66%61%71%2e%67%6d%69", "gemini://gemini.circumlunar.space/docs/faq.gmi"},
+	//{"gemini://geminiprotocol.net/%64%6f%63%73/%66%61%71%2e%67%6d%69", "gemini://geminiprotocol.net/docs/faq.gmi"},
 	{"gemini://example.com/蛸", "gemini://example.com/%E8%9B%B8"},
-	//{"gemini://gemini.circumlunar.space/%64%6f%63%73/;;.'%66%61%71蛸%2e%67%6d%69", "gemini://gemini.circumlunar.space/docs/%3B%3B.%27faq%E8%9B%B8.gmi"},
+	//{"gemini://geminiprotocol.net/%64%6f%63%73/;;.'%66%61%71蛸%2e%67%6d%69", "gemini://geminiprotocol.net/docs/%3B%3B.%27faq%E8%9B%B8.gmi"},
 	{"gemini://example.com/?%2Ch%64ello蛸", "gemini://example.com/?%2Chdello%E8%9B%B8"},
 	// IPv6 tests, see #195
 	{"gemini://[::1]", "gemini://[::1]/"},

--- a/config/config.go
+++ b/config/config.go
@@ -190,7 +190,7 @@ func Init() error {
 
 	// Setup main config
 
-	viper.SetDefault("a-general.home", "gemini://gemini.circumlunar.space")
+	viper.SetDefault("a-general.home", "gemini://geminiprotocol.net")
 	viper.SetDefault("a-general.auto_redirect", false)
 	viper.SetDefault("a-general.http", "default")
 	viper.SetDefault("a-general.search", "gemini://geminispace.info/search")

--- a/config/default.go
+++ b/config/default.go
@@ -25,7 +25,7 @@ var defaultConf = []byte(`# This is the default config file.
 
 [a-general]
 # Press Ctrl-H to access it
-home = "gemini://gemini.circumlunar.space"
+home = "gemini://geminiprotocol.net"
 
 # Follow up to 5 Gemini redirects without prompting.
 # A prompt is always shown after the 5th redirect and for redirects to protocols other than Gemini.

--- a/default-config.toml
+++ b/default-config.toml
@@ -22,7 +22,7 @@
 
 [a-general]
 # Press Ctrl-H to access it
-home = "gemini://gemini.circumlunar.space"
+home = "gemini://geminiprotocol.net"
 
 # Follow up to 5 Gemini redirects without prompting.
 # A prompt is always shown after the 5th redirect and for redirects to protocols other than Gemini.

--- a/display/newtab.go
+++ b/display/newtab.go
@@ -29,7 +29,7 @@ Happy browsing!
 => https://github.com/makeworld-the-better-one/amfora/wiki Amfora Wiki [GitHub]
 => gemini://makeworld.space/amfora-wiki/ Amfora Wiki [On Gemini!]
 
-=> gemini://gemini.circumlunar.space Project Gemini
+=> gemini://geminiprotocol.net Project Gemini
 `
 
 // Read the new tab content from a file if it exists or fallback to a default page.


### PR DESCRIPTION
These changes update the URLs used for the official Project Gemini capsule[^1], including those used in the default config file and for new tabs.

Currently, in version `1.9.2`, the original URL[^2] presents the following page:

<img width="962" alt="Screenshot 2023-10-17 at 18 51 20" src="https://github.com/makew0rld/amfora/assets/679401/c1069968-f4f5-46dc-8011-8b87496c18ba">

[^1]: Original news article: [2023-08-14 - Changing domain names](https://geminiprotocol.net/news/2023_08_14.gmi)
[^2]: `gemini://gemini.circumlunar.space`