### PR TITLE
Use preformatted_text color for rendering plain text files

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -49,7 +49,7 @@ func RenderPlainText(s string) string {
 	// It used to add a left margin, now this is done elsewhere.
 	// The function is kept for convenience and in case rendering
 	// is needed in the future.
-	return cview.Escape(s)
+	return fmt.Sprintf("[%s]", config.GetColorString("preformatted_text")) + cview.Escape(s)
 }
 
 // wrapLine wraps a line to the provided width, and adds the provided prefix and suffix to each wrapped line.


### PR DESCRIPTION
Using a color from the theme should make the rendering of text files be more in line with the colors chosen for styled content. Furthermore, allowing some form of user override for the color of plain text files allows users to individually fix bad color combinations. Such as in my case, where the combination of a solarized terminal theme and the default color chosen by amfora causes plain text files to be rendered as white text on an almost equally bright background.