### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clicking "Change" on an existing bookmark without changing the text no longer removes it (#91)
 - Display HTTP Error if "Open In Portal" fails (#81)
 - Support ANSI color codes again, but only in preformatted blocks (#59)
-- Make the `..` command work lke it used to in v1.4.0
+- Make the `..` command work like it used to in v1.4.0
 
 
 ## [1.5.0] - 2020-09-01

--- a/config/default.go
+++ b/config/default.go
@@ -251,7 +251,7 @@ underline = true
 # DO NOT use this for setting the HTTP command.
 # Use the http setting in the "a-general" section above.
 #
-# NOTE: These settings are overrided by the ones in the proxies section.
+# NOTE: These settings are overridden by the ones in the proxies section.
 #
 # The best way to define a command is using a string array.
 # Examples:

--- a/config/theme.go
+++ b/config/theme.go
@@ -27,7 +27,7 @@ var theme = map[string]tcell.Color{
 	"ColorFg": ColorFg,
 
 	// Default values below
-	// Only the 16 Xterm system tcell.Colors are used, because those are the tcell.Colors overrided
+	// Only the 16 Xterm system tcell.Colors are used, because those are the tcell.Colors overridden
 	// by the user's default terminal theme
 
 	// Used for cview.Styles.PrimitiveBackgroundColor

--- a/default-config.toml
+++ b/default-config.toml
@@ -248,7 +248,7 @@ underline = true
 # DO NOT use this for setting the HTTP command.
 # Use the http setting in the "a-general" section above.
 #
-# NOTE: These settings are overrided by the ones in the proxies section.
+# NOTE: These settings are overridden by the ones in the proxies section.
 #
 # The best way to define a command is using a string array.
 # Examples:

--- a/display/handlers.go
+++ b/display/handlers.go
@@ -204,14 +204,14 @@ func handleURL(t *tab, u string, numRedirects int) (string, bool) {
 	defer App.Draw() // Just in case
 
 	// Save for resetting on error
-	oldLable := t.barLabel
+	oldLabel := t.barLabel
 	oldText := t.barText
 
 	// Custom return function
 	ret := func(s string, b bool) (string, bool) {
 		if !b {
 			// Reset bottomBar if page wasn't loaded
-			t.barLabel = oldLable
+			t.barLabel = oldLabel
 			t.barText = oldText
 		}
 		t.mode = tabModeDone

--- a/display/tab.go
+++ b/display/tab.go
@@ -284,7 +284,7 @@ func makeNewTab() *tab {
 			// Scrolling to the right
 
 			if t.page.Column >= leftMargin() {
-				// Scrolled right far enought that no left margin is needed
+				// Scrolled right far enough that no left margin is needed
 				if (t.page.Column-leftMargin())+boxW >= width {
 					// And scrolled as far as possible to the right
 					return nil

--- a/display/util.go
+++ b/display/util.go
@@ -44,7 +44,7 @@ func tabNumber(t *tab) int {
 	return -1
 }
 
-// escapeMeta santizes a META string for use within a cview modal.
+// escapeMeta sanitizes a META string for use within a cview modal.
 func escapeMeta(meta string) string {
 	return cview.Escape(strings.ReplaceAll(meta, "\n", ""))
 }


### PR DESCRIPTION
Found via `codespell -L ans,nd` and `typos --hidden --format brief`