### PR TITLE
Fix build error resulting from cview's move to codeberg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,3 +56,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace code.rocketnine.space/tslocum/cview => codeberg.org/tslocum/cview v1.5.6-0.20210530175404-7e8817f20bdc

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 code.rocketnine.space/tslocum/cbind v0.1.5 h1:i6NkeLLNPNMS4NWNi3302Ay3zSU6MrqOT+yJskiodxE=
 code.rocketnine.space/tslocum/cbind v0.1.5/go.mod h1:LtfqJTzM7qhg88nAvNhx+VnTjZ0SXBJtxBObbfBWo/M=
-code.rocketnine.space/tslocum/cview v1.5.6-0.20210530175404-7e8817f20bdc h1:nAcBp7ZCWHpa8fHpynCbULDTAZgPQv28+Z+QnhnFG7E=
-code.rocketnine.space/tslocum/cview v1.5.6-0.20210530175404-7e8817f20bdc/go.mod h1:KBRxzIsj8bfgFpnMpkGVoxsrPUvnQsRnX29XJ2yzB6M=
+codeberg.org/tslocum/cview v1.5.6-0.20210530175404-7e8817f20bdc h1:e/aOXAZQlclmYpKW33oa6VZRFc/PA6O/70ijdAZJmo4=
+codeberg.org/tslocum/cview v1.5.6-0.20210530175404-7e8817f20bdc/go.mod h1:KBRxzIsj8bfgFpnMpkGVoxsrPUvnQsRnX29XJ2yzB6M=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=


### PR DESCRIPTION
Recently tried to `brew install --HEAD amfora` to get the latest and greatest, only to encounter a build failure.

Turns out this was a result of cview migrating their repo to codeberg:
https://codeberg.org/tslocum/cview/commit/242e7c1f1b61a4b3722a1afb45ca1165aefa9a59

Added a replace directive to point to the new location, and `make` now results in a successful build.